### PR TITLE
Phrase highlighting

### DIFF
--- a/default.css
+++ b/default.css
@@ -99,3 +99,48 @@ label {
 #canvas {
   cursor: pointer;
 }
+
+.wrapper {
+  position: relative;
+  width: 100%;
+  height: fit-content;
+}
+
+#highlight,
+#code {
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-size: 14px;
+  line-height: 1.4;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+#code {
+  position: relative;
+  z-index: 2;
+  background: transparent;
+  color: black;
+  width: 100%;
+  height: 7em;
+  resize: vertical;
+  border: 1px solid #ccc;
+}
+
+#highlight {
+  position: absolute;
+  top: 0;
+  left: 0;
+  color: transparent;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1;
+  border: 1px solid transparent;
+}
+
+mark {
+  background: rgba(255, 255, 0, 0.4);
+}

--- a/highlight.js
+++ b/highlight.js
@@ -1,0 +1,63 @@
+// jsSyntaxTree - A syntax tree graph generator
+// highlighting to aid those with a visual impairment
+// Enrique Lopez, Oct 12 2025 
+
+export function setupBracketHighlighting(textareaId = "code", highlightId = "highlight") {
+  const editor = document.getElementById(textareaId);
+  const highlight = document.getElementById(highlightId);
+  if (!editor || !highlight) return;
+
+
+document.addEventListener('DOMContentLoaded', () => {
+    const editor = document.getElementById('code');
+    const highlight = document.getElementById('highlight');
+
+});
+
+  function escapeHTML(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function updateHighlight(cursorPos = null) {
+    const text = editor.value;
+    let openStack = [];
+    let highlightStart = null;
+    let highlightEnd = null;
+
+    for (let i = 0; i < text.length; i++) {
+      if (text[i] === '[') openStack.push(i);
+      else if (text[i] === ']') {
+        const start = openStack.pop();
+        if (start !== undefined && cursorPos >= start && cursorPos <= i) {
+          highlightStart = start;
+          highlightEnd = i;
+          break;
+        }
+      }
+    }
+
+    let html = '';
+    for (let i = 0; i < text.length; i++) {
+      if (i === highlightStart) html += '<mark>';
+      html += escapeHTML(text[i]);
+      if (i === highlightEnd) html += '</mark>';
+    }
+
+    highlight.innerHTML = html;
+    highlight.scrollTop = editor.scrollTop;
+    highlight.scrollLeft = editor.scrollLeft;
+  }
+
+  editor.addEventListener('input', () => updateHighlight());
+  editor.addEventListener('click', () => updateHighlight(editor.selectionStart));
+  editor.addEventListener('keyup', () => updateHighlight(editor.selectionStart));
+  editor.addEventListener('scroll', () => {
+    highlight.scrollTop = editor.scrollTop;
+    highlight.scrollLeft = editor.scrollLeft;
+  });
+
+  updateHighlight();
+}

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <link rel="stylesheet" type="text/css" href="default.css" />
 <link rel="manifest" href="syntaxtree.webmanifest" />
 <script type="module" src="syntaxtree.js" async></script>
+<script type="module" src="highlight.js" defer></script>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name='viewport' content='width=device-width, initial-scale=1' />
 <meta name="author" content="Andre Eisenbach" />
@@ -45,7 +46,10 @@
 
 <div id="input">
   <h2>Phrase (labelled bracket notation)</h2>
-  <textarea rows="5" id="code">[S [NP jsSyntaxTree][VP [V creates][NP nice syntax trees ->1]]]</textarea>
+    <div class="wrapper">
+      <pre id="highlight"></pre>
+      <textarea rows="5" id="code">[S [NP jsSyntaxTree][VP [V creates][NP nice syntax trees ->1]]]</textarea>
+    </div>
   <span id="parse-error"></span>
 </div>
 
@@ -60,3 +64,4 @@
   <a href="https://github.com/int2str/jssyntaxtree">https://github.com/int2str/jssyntaxtree</a>
   <div id="version">&nbsp;</div>
 </footer>
+


### PR DESCRIPTION
Added phrase highlighting which will result in phrases with an unmatched closing bracket to not be highlighted, but phrases with both brackets will be highlighted.

I created this feature for my professor as she mentioned the brackets are hard to see for her (she has a visual impairment)

There have been slight edits to index.html and default.css, as well as a new file highlight.js which contains
the logic behind the highlight feature