### PR TITLE
State encodings of text-area into URL

### DIFF
--- a/state.js
+++ b/state.js
@@ -1,0 +1,16 @@
+// jsSyntaxTree - A syntax tree graph generator
+// State encoding and decoding for states embedded in the URL
+// Enrique Lopez, Nov 20th, 2025
+
+export function encodeState(str) {
+  const utf8 = new TextEncoder().encode(str);
+  const base64 = btoa(String.fromCharCode(...utf8));
+  return encodeURIComponent(base64);
+}
+
+export function decodeState(encoded) {
+  const base64 = decodeURIComponent(encoded);
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}

--- a/tip.js
+++ b/tip.js
@@ -16,6 +16,7 @@ const tips = [
     'Example: <a href="?[&quot;Main%20clause&quot;%20[S][V][O]]">[&quot;Main clause&quot; [S][V][O]]</a>',
   "Add arrows to a node by using an -&gt;, &lt- or &lt;&gt; arrow followed by column number.<br />" +
     'Example: <a href="?[A%20[B%20C][D%20E][F%20G%20->1]]">[A [B C][D E][F G ->1]]</a>',
+    "You can copy-and-paste the URL to save your work for later or send to a friend!",
 ];
 
 let tip_idx = Math.floor(Math.random() * tips.length);


### PR DESCRIPTION
- encodes text-area into a URL hash, allowing users to copy-and-paste the
- URL to share or work on later.
- Implements the feature requested by jakupmichaelsen
- Uses a hash-based approach rather than a more verbatim approach.
- Supports Unicode and preserves indentation
- Added logic in syntaxtree.js for the encoding/decoding
- Created state.js for the state-encoding helper functions
- Updated tip.js to inform users of the new feature

Additionally, this feature was tested on an http server on Firefox, Safari and Chrome. All worked as intended from my testing.